### PR TITLE
then->than

### DIFF
--- a/_posts/2020-02-23-week04.md
+++ b/_posts/2020-02-23-week04.md
@@ -23,7 +23,7 @@ title: Week 4
 
 This week I made several contributions to OpenStreetMap. I added a new *Comfort Inn* hotel to the map, in addition to a local deli, a *Dollar Tree* store, and an exotic lighting store to the map. The specifics of these contributions (including a link to the contributions themselves) can be found in the *Contributions* tab above. 
 
-I also had the opportunity to make a pull request to a fellow student's blog post this week. Here, I suggested a few amendments to sentence structure for clarity, rephrased a few thoughts, and got captured by my peer's story. Proposing blog edits for a peer was a lot more fun then expected. It was a great opportunity to *actually* read someone else's thoughts on FOSS projects and learn about what their interests were. I also had the opportunity to learn about what projects I should stay away from :grin:!
+I also had the opportunity to make a pull request to a fellow student's blog post this week. Here, I suggested a few amendments to sentence structure for clarity, rephrased a few thoughts, and got captured by my peer's story. Proposing blog edits for a peer was a lot more fun than expected. It was a great opportunity to *actually* read someone else's thoughts on FOSS projects and learn about what their interests were. I also had the opportunity to learn about what projects I should stay away from :grin:!
 
 ---
 #### *'Til next time,*


### PR DESCRIPTION
I found a minor error in the following sentence:

"Proposing blog edits for a peer was a lot more fun **then** expected."

I think you meant to write "than" as your sentence suggests a comparison.
